### PR TITLE
Adjustments made to facilitate upgrades

### DIFF
--- a/src/calico_manifests.py
+++ b/src/calico_manifests.py
@@ -68,7 +68,8 @@ class PatchValuesKubeControllers(Patch):
                 env = container.env
                 for e in env:
                     if e.name.startswith("ETCD"):
-                        e.value = None
+                        # blank the `value` with <space> field rather using `None`
+                        e.value = ""
 
 
 class SetAnnotationCalicoNode(Patch):

--- a/src/charm.py
+++ b/src/charm.py
@@ -29,7 +29,6 @@ log = logging.getLogger(__name__)
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 
 CALICO_CTL_PATH = "/opt/calicoctl"
-CNI_BIN_PATH = "/opt/cni/bin"
 CALICO_CNI_CONFIG_PATH = "/etc/cni/net.d/10-calico.conflist"
 ETCD_KEY_PATH = os.path.join(CALICO_CTL_PATH, "etcd-key")
 ETCD_CERT_PATH = os.path.join(CALICO_CTL_PATH, "etcd-cert")
@@ -227,20 +226,6 @@ class CalicoCharm(ops.CharmBase):
             log.info(f"{service_name} service removed and daemon reloaded.")
         else:
             log.info(f"{service_name} service successfully uninstalled.")
-
-        # Remove calico-node binaries
-        calico_path = os.path.join(os.sep, CNI_BIN_PATH, "calico")
-        if os.path.isfile(calico_path):
-            os.remove(calico_path)
-            log.info("calico binary uninstalled.")
-        else:
-            log.info("calico binary successfully uninstalled.")
-        ipam_path = os.path.join(os.sep, CNI_BIN_PATH, "calico-ipam")
-        if os.path.isfile(ipam_path):
-            os.remove(ipam_path)
-            log.info("calico-ipam binary uninstalled.")
-        else:
-            log.info("calico-ipam binary successfully uninstalled.")
 
     def _get_ip_versions(self) -> Set[int]:
         return {net.version for net in self._get_networks(self.config["cidr"])}

--- a/src/charm.py
+++ b/src/charm.py
@@ -538,16 +538,16 @@ class CalicoCharm(ops.CharmBase):
 
     def _list_resources(self, event):
         resources = event.params.get("resources", "")
-        return self.collector.list_resources(event, resources=resources)
+        return self.collector.list_resources(event, manifests=None, resources=resources)
 
     def _scrub_resources(self, event):
         resources = event.params.get("resources", "")
-        return self.collector.scrub_resources(event, resources=resources)
+        return self.collector.scrub_resources(event, manifests=None, resources=resources)
 
     def _sync_resources(self, event):
         resources = event.params.get("resources", "")
         try:
-            self.collector.apply_missing_resources(event, resources=resources)
+            self.collector.apply_missing_resources(event, manifests=None, resources=resources)
         except ManifestClientError:
             msg = "Failed to apply missing resources. API Server unavailable."
             event.set_results({"result": msg})

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -332,7 +332,6 @@ def test_remove_calico_reactive(
     detected: bool,
 ):
     service_path = os.path.join(os.sep, "lib", "systemd", "system", "calico-node.service")
-    cni_bin_path = "/opt/cni/bin/"
     mocks = (mock_running, mock_stop, mock_reload, mock_isfile)
 
     for mock_obj in mocks:
@@ -344,8 +343,6 @@ def test_remove_calico_reactive(
     mock_isfile.assert_has_calls(
         [
             mock.call(service_path),
-            mock.call(cni_bin_path + "calico"),
-            mock.call(cni_bin_path + "calico-ipam"),
         ]
     )
 
@@ -355,20 +352,14 @@ def test_remove_calico_reactive(
         mock_remove.assert_has_calls(
             [
                 mock.call(service_path),
-                mock.call(cni_bin_path + "calico"),
-                mock.call(cni_bin_path + "calico-ipam"),
             ]
         )
 
         assert "calico-node service stopped." in caplog.text
         assert "calico-node service removed and daemon reloaded." in caplog.text
-        assert "calico binary uninstalled." in caplog.text
-        assert "calico-ipam binary uninstalled." in caplog.text
     else:
         assert "calico-node service successfully stopped." in caplog.text
         assert "calico-node service successfully uninstalled." in caplog.text
-        assert "calico binary successfully uninstalled." in caplog.text
-        assert "calico-ipam binary successfully uninstalled." in caplog.text
 
 
 @mock.patch("charm.CalicoCharm._get_networks")


### PR DESCRIPTION
* Fixes an issue running this action
  - `ops.manifest` collector methods all have a required argument that isn't filled in.  
* Resolves an upgrade issue where the container env `value` field wasn't being blanked properly to make room for `valueFrom`
* Resolves an upgrade issue where calico-node daemonset install calico binaries, but the charm may remove them.  