### PR TITLE
load the arm64 resource on arm64 machines

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -462,7 +462,7 @@ class CalicoCharm(ops.CharmBase):
         resource_name = "calico" if arch == "amd64" else f"calico-{arch}"
 
         try:
-            resource_path = self.model.resources.fetch("calico")
+            resource_path = self.model.resources.fetch(resource_name)
         except ModelError:
             self.unit.status = BlockedStatus(f"Error claiming {resource_name}")
             log.exception(f"Error claiming {resource_name}")


### PR DESCRIPTION
ensure the correct `resource_name` is pulled when installing for `arm64`