### PR TITLE
[LP#2031564]Use conctl to kill calico-node with fire

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ops >= 2.2.0
 lightkube
 ops.manifest >= 1.1.0
+git+https://github.com/charmed-kubernetes/conctl@c1eaaac#egg=conctl

--- a/src/charm.py
+++ b/src/charm.py
@@ -42,8 +42,9 @@ def conctl_stop(container):
     try:
         proc = ctl.delete(container)
     except CalledProcessError as e:
-        if f"{container} not found" not in e.stderr.decode():
-            raise
+        if f"{container} not found" in e.stderr.decode():
+            return True
+        raise
     return proc.returncode == 0
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -42,7 +42,7 @@ def conctl_stop(container):
     try:
         proc = ctl.delete(container)
     except CalledProcessError as e:
-        if f"{container} not found" in e.stderr.decode():
+        if b"not found" in e.stderr:
             return True
         raise
     return proc.returncode == 0

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,6 +20,7 @@ import yaml
 from calico_manifests import CalicoManifests
 from charms.kubernetes_libs.v0.etcd import EtcdReactiveRequires
 from charms.operator_libs_linux.v1.systemd import daemon_reload, service_running, service_stop
+from conctl import getContainerRuntimeCtl
 from ops.framework import StoredState
 from ops.manifests import Collector, ManifestClientError
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError, WaitingStatus
@@ -33,6 +34,17 @@ CALICO_CNI_CONFIG_PATH = "/etc/cni/net.d/10-calico.conflist"
 ETCD_KEY_PATH = os.path.join(CALICO_CTL_PATH, "etcd-key")
 ETCD_CERT_PATH = os.path.join(CALICO_CTL_PATH, "etcd-cert")
 ETCD_CA_PATH = os.path.join(CALICO_CTL_PATH, "etcd-ca")
+
+
+def conctl_stop(container):
+    """Stop a container with runc independent conctl."""
+    ctl = getContainerRuntimeCtl()
+    try:
+        proc = ctl.delete(container)
+    except CalledProcessError as e:
+        if f"{container} not found" not in e.stderr.decode():
+            raise
+    return proc.returncode == 0
 
 
 class CalicoCharm(ops.CharmBase):
@@ -219,6 +231,9 @@ class CalicoCharm(ops.CharmBase):
                 log.info(f"{service_name} service stopped.")
         else:
             log.info(f"{service_name} service successfully stopped.")
+
+        if conctl_stop(service_name):
+            log.info(f"{service_name} container stopped.")
 
         if os.path.isfile(service_path):
             os.remove(service_path)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,3 +49,9 @@ def charm(request, harness: Harness[CalicoCharm]):
 def lk_client():
     with mock.patch("ops.manifests.manifest.Client", autospec=True) as mock_lightkube:
         yield mock_lightkube.return_value
+
+
+@pytest.fixture(autouse=True)
+def conctl():
+    with mock.patch("charm.getContainerRuntimeCtl", autospec=True) as mock_conctl:
+        yield mock_conctl.return_value

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ import unittest.mock as mock
 from asyncio import subprocess
 from ipaddress import ip_network
 from pathlib import Path
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, CompletedProcess
 from typing import Optional, Set
 
 import ops
@@ -328,6 +328,7 @@ def test_remove_calico_reactive(
     mock_stop: mock.MagicMock,
     mock_running: mock.MagicMock,
     charm: CalicoCharm,
+    conctl,
     caplog,
     detected: bool,
 ):
@@ -345,6 +346,8 @@ def test_remove_calico_reactive(
             mock.call(service_path),
         ]
     )
+    conctl.delete.return_value = CompletedProcess([], 0)
+    conctl.delete.assert_called_once_with("calico-node")
 
     if detected:
         mock_stop.assert_called_once_with("calico-node")


### PR DESCRIPTION
[LP#2031564](https://bugs.launchpad.net/charm-calico/+bug/2031564) 

Found that calico-node containers were still running on upgrade units due to the service stop relying on executing the conctl binary -- which has now been removed from the charm environment. 


Will need urgent backport to `release_1.28` branch and have new beta charms built