### PR TITLE
Fix `assign_ipv4` and `assign_ipv6`

### DIFF
--- a/src/calico_manifests.py
+++ b/src/calico_manifests.py
@@ -311,14 +311,13 @@ class CalicoManifests(Manifests):
         config: Returns the configuration mapped from the charm config and joined relations.
     """
 
-    def __init__(self, charm, charm_config, etcd: EtcdReactiveRequires, cni_config: dict):
+    def __init__(self, charm, charm_config, etcd: EtcdReactiveRequires):
         """Initialize an instance of CalicoManifests.
 
         Args:
             charm (CharmBase): The Calico charm object.
             charm_config (dict): The charm configuration.
             etcd (EtcdReactiveRequires): The Etcd relation object.
-            cni_config (dict): The CNI (Container Network Interface) configuration.
         """
         manipulations = [
             ConfigRegistry(self),
@@ -338,7 +337,7 @@ class CalicoManifests(Manifests):
         super().__init__("calico", charm.model, "upstream/calico", manipulations)
         self.charm_config = charm_config
         self.etcd = etcd
-        self.cni_config = cni_config
+        self.cni_config = {}
 
     @property
     def config(self) -> Dict:

--- a/src/calico_manifests.py
+++ b/src/calico_manifests.py
@@ -311,13 +311,14 @@ class CalicoManifests(Manifests):
         config: Returns the configuration mapped from the charm config and joined relations.
     """
 
-    def __init__(self, charm, charm_config, etcd: EtcdReactiveRequires):
+    def __init__(self, charm, charm_config, etcd: EtcdReactiveRequires, cni_config: dict):
         """Initialize an instance of CalicoManifests.
 
         Args:
             charm (CharmBase): The Calico charm object.
             charm_config (dict): The charm configuration.
             etcd (EtcdReactiveRequires): The Etcd relation object.
+            cni_config (dict): The CNI (Container Network Interface) configuration.
         """
         manipulations = [
             ConfigRegistry(self),
@@ -337,7 +338,7 @@ class CalicoManifests(Manifests):
         super().__init__("calico", charm.model, "upstream/calico", manipulations)
         self.charm_config = charm_config
         self.etcd = etcd
-        self.cni_config = {}
+        self.cni_config = cni_config
 
     @property
     def config(self) -> Dict:

--- a/src/calico_manifests.py
+++ b/src/calico_manifests.py
@@ -112,7 +112,7 @@ class PatchVethMtu(Patch):
             log.warning("calico-config: Unable to patch MTU value, data not found.")
             return
         mtu = self.manifests.config.get("mtu")
-        data.update({"veth_mtu": mtu if mtu else "0"})
+        data.update({"veth_mtu": str(mtu) if mtu else "0"})
 
 
 class PatchCalicoConflist(Patch):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -708,12 +708,12 @@ def test_configure_cni(
     ip_versions: Set,
     expected_config: dict,
 ):
-    charm.stored.cni_configure = False
+    charm.stored.cni_configured = False
     mock_get_ip.return_value = ip_versions
 
     charm._configure_cni()
 
-    assert charm.calico_manifests.cni_config == expected_config
+    assert charm.cni_config == expected_config
     assert charm.stored.cni_configured
     mock_mtu.assert_called_once()
     mock_propagate.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -693,7 +693,7 @@ def test_configure_bgp_peers_raises(
                 "assign_ipv6": "false",
                 "IP6": "none",
             },
-            id="Dualstack",
+            id="Singlestack",
         ),
     ],
 )
@@ -713,7 +713,7 @@ def test_configure_cni(
 
     charm._configure_cni()
 
-    assert charm.cni_options == expected_config
+    assert charm.calico_manifests.cni_config == expected_config
     assert charm.stored.cni_configured
     mock_mtu.assert_called_once()
     mock_propagate.assert_called_once()


### PR DESCRIPTION
## Summary
The charm is configuring Calico `assign_ipv{4,6}` as null instead of the actual value.
## Changes
- Added a call to reconfigure the `cni_config` when the charm configuration or the etcd config changes.