### PR TITLE
LP#2037236 Calico is ignoring juju network binding for cni

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 
 # Contributor Guide
 
-This Juju charm is open source ([Apache License 2.0](./LICENSE)) and we actively seek any community contibutions
+This Juju charm is open source ([Apache License 2.0](./LICENSE)) and we actively seek any community contributions
 for code, suggestions and documentation.
 This page details a few notes, workflows and suggestions for how to make contributions most effective and help us
 all build a better charm - please give them a read before working on any contributions.

--- a/src/calico_manifests.py
+++ b/src/calico_manifests.py
@@ -73,7 +73,9 @@ class PatchIPAutodetectionMethod(Patch):
         for container in containers:
             if container.name == "calico-node":
                 env = container.env
-                ipauto_env = EnvVar("IP_AUTODETECTION_METHOD", "skip-interface=lxd.*,fan.*")
+                ipauto_env = EnvVar(
+                    "IP_AUTODETECTION_METHOD", f"cidr={self.manifests.config.get('ipv4_cidr')}"
+                )
                 env.append(ipauto_env)
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -405,14 +405,24 @@ class CalicoCharm(ops.CharmBase):
 
     def _get_cni_config(self):
         """Get the CNI config options."""
+        binding = self.model.get_binding("cni")
+
+        ipv4_cidr = next(
+            (
+                iface.subnet
+                for iface in binding.network.interfaces
+                if not iface.name.startswith("fan-")
+            ),
+            None,
+        )
         ip_versions = self._get_ip_versions()
-        ip6 = "autodetect" if 6 in ip_versions else "none"
         return {
             "kubeconfig_path": "/opt/calicoctl/kubeconfig",
             "mtu": self._get_mtu(),
             "assign_ipv4": "true" if 4 in ip_versions else "false",
             "assign_ipv6": "true" if 6 in ip_versions else "false",
-            "IP6": ip6,
+            "IP6": "autodetect" if 6 in ip_versions else "none",
+            "ipv4_cidr": str(ipv4_cidr),
         }
 
     def _disable_vxlan_tx_checksumming(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -407,13 +407,10 @@ class CalicoCharm(ops.CharmBase):
         """Get the CNI config options."""
         binding = self.model.get_binding("cni")
 
-        ipv4_cidr = next(
-            (
-                iface.subnet
-                for iface in binding.network.interfaces
-                if not iface.name.startswith("fan-")
-            ),
-            None,
+        ipv4_cidr, *_ = (
+            iface.subnet
+            for iface in binding.network.interfaces
+            if not iface.name.startswith("fan-")
         )
         ip_versions = self._get_ip_versions()
         return {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,6 +12,7 @@ ops.testing.SIMULATE_CAN_CONNECT = True
 def pytest_configure(config):
     markers = {
         "skip_install_calico_binaries": "mark tests which do not mock out _install_calico_binaries",
+        "skip_get_cni_config": "mark tests which do not mock out _get_cni_config",
     }
     for marker, description in markers.items():
         config.addinivalue_line("markers", f"{marker}: {description}")
@@ -30,12 +31,13 @@ def harness():
 def charm(request, harness: Harness[CalicoCharm]):
     """Create a charm with mocked methods.
 
-    This fixture utilizes ExitStack to dynamically mock methods in the Cilium Charm,
+    This fixture utilizes ExitStack to dynamically mock methods in the Calico Charm,
     using the request markers defined in the `pytest_configure` method.
     """
     with contextlib.ExitStack() as stack:
         methods_to_mock = {
             "_install_calico_binaries": "skip_install_calico_resources",
+            "_get_cni_config": "skip_get_cni_config",
         }
         for method, marker in methods_to_mock.items():
             if marker not in request.keywords:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -681,7 +681,7 @@ def test_configure_bgp_peers_raises(
                 "assign_ipv4": "true",
                 "assign_ipv6": "true",
                 "IP6": "autodetect",
-                "ipv4_cidr": "10.0.0.0/16"
+                "ipv4_cidr": "10.0.0.0/16",
             },
             id="Dualstack",
         ),
@@ -693,7 +693,7 @@ def test_configure_bgp_peers_raises(
                 "assign_ipv4": "true",
                 "assign_ipv6": "false",
                 "IP6": "none",
-                "ipv4_cidr": "10.0.0.0/16"
+                "ipv4_cidr": "10.0.0.0/16",
             },
             id="Singlestack",
         ),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -681,6 +681,7 @@ def test_configure_bgp_peers_raises(
                 "assign_ipv4": "true",
                 "assign_ipv6": "true",
                 "IP6": "autodetect",
+                "ipv4_cidr": "10.0.0.0/16"
             },
             id="Dualstack",
         ),
@@ -692,6 +693,7 @@ def test_configure_bgp_peers_raises(
                 "assign_ipv4": "true",
                 "assign_ipv6": "false",
                 "IP6": "none",
+                "ipv4_cidr": "10.0.0.0/16"
             },
             id="Singlestack",
         ),
@@ -700,23 +702,31 @@ def test_configure_bgp_peers_raises(
 @mock.patch("charm.CalicoCharm._propagate_cni_config")
 @mock.patch("charm.CalicoCharm._get_ip_versions")
 @mock.patch("charm.CalicoCharm._get_mtu", return_value=1500)
+@pytest.mark.skip_get_cni_config
 def test_configure_cni(
     mock_mtu: mock.MagicMock,
     mock_get_ip: mock.MagicMock,
     mock_propagate: mock.MagicMock,
+    harness: Harness,
     charm: CalicoCharm,
     ip_versions: Set,
     expected_config: dict,
 ):
     charm.stored.cni_configured = False
     mock_get_ip.return_value = ip_versions
+    with mock.patch.object(charm.model, "get_binding") as mock_binding:
+        mock_interface = mock.MagicMock()
+        mock_interface.name = "mockIface"
+        mock_interface.subnet = "10.0.0.0/16"
+        mock_binding.network.interfaces = [mock_interface]
+        mock_binding.return_value = mock_binding
 
-    charm._configure_cni()
+        charm._configure_cni()
 
-    assert charm.cni_config == expected_config
-    assert charm.stored.cni_configured
-    mock_mtu.assert_called_once()
-    mock_propagate.assert_called_once()
+        assert charm.cni_config == expected_config
+        assert charm.stored.cni_configured
+        mock_mtu.assert_called_once()
+        mock_propagate.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/upstream/update.py
+++ b/upstream/update.py
@@ -80,7 +80,7 @@ class Release:
         return hash(self.name)
 
     def __eq__(self, other) -> bool:
-        """Comparible based on its name."""
+        """Comparable based on its name."""
         return isinstance(other, Release) and self.name == other.name
 
     def __lt__(self, other) -> bool:


### PR DESCRIPTION
## Summary
This pull request fixes the auto-detection method for IPv4.

## Description
The `IP_AUTODETECTION_METHOD` for IPv4 has been changed from `skip` to `cidr`. The CIDR used in this configuration value is sourced from the `cni` binding endpoint.