### PR TITLE
[Backport] LP#2037236 Calico is ignoring juju network binding for cni (#104)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 
 # Contributor Guide
 
-This Juju charm is open source ([Apache License 2.0](./LICENSE)) and we actively seek any community contibutions
+This Juju charm is open source ([Apache License 2.0](./LICENSE)) and we actively seek any community contributions
 for code, suggestions and documentation.
 This page details a few notes, workflows and suggestions for how to make contributions most effective and help us
 all build a better charm - please give them a read before working on any contributions.

--- a/src/calico_manifests.py
+++ b/src/calico_manifests.py
@@ -73,7 +73,9 @@ class PatchIPAutodetectionMethod(Patch):
         for container in containers:
             if container.name == "calico-node":
                 env = container.env
-                ipauto_env = EnvVar("IP_AUTODETECTION_METHOD", "skip-interface=lxd.*,fan.*")
+                ipauto_env = EnvVar(
+                    "IP_AUTODETECTION_METHOD", f"cidr={self.manifests.config.get('ipv4_cidr')}"
+                )
                 env.append(ipauto_env)
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -405,14 +405,21 @@ class CalicoCharm(ops.CharmBase):
 
     def _get_cni_config(self):
         """Get the CNI config options."""
+        binding = self.model.get_binding("cni")
+
+        ipv4_cidr, *_ = (
+            iface.subnet
+            for iface in binding.network.interfaces
+            if not iface.name.startswith("fan-")
+        )
         ip_versions = self._get_ip_versions()
-        ip6 = "autodetect" if 6 in ip_versions else "none"
         return {
             "kubeconfig_path": "/opt/calicoctl/kubeconfig",
             "mtu": self._get_mtu(),
             "assign_ipv4": "true" if 4 in ip_versions else "false",
             "assign_ipv6": "true" if 6 in ip_versions else "false",
-            "IP6": ip6,
+            "IP6": "autodetect" if 6 in ip_versions else "none",
+            "ipv4_cidr": str(ipv4_cidr),
         }
 
     def _disable_vxlan_tx_checksumming(self):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,6 +12,7 @@ ops.testing.SIMULATE_CAN_CONNECT = True
 def pytest_configure(config):
     markers = {
         "skip_install_calico_binaries": "mark tests which do not mock out _install_calico_binaries",
+        "skip_get_cni_config": "mark tests which do not mock out _get_cni_config",
     }
     for marker, description in markers.items():
         config.addinivalue_line("markers", f"{marker}: {description}")
@@ -30,12 +31,13 @@ def harness():
 def charm(request, harness: Harness[CalicoCharm]):
     """Create a charm with mocked methods.
 
-    This fixture utilizes ExitStack to dynamically mock methods in the Cilium Charm,
+    This fixture utilizes ExitStack to dynamically mock methods in the Calico Charm,
     using the request markers defined in the `pytest_configure` method.
     """
     with contextlib.ExitStack() as stack:
         methods_to_mock = {
             "_install_calico_binaries": "skip_install_calico_resources",
+            "_get_cni_config": "skip_get_cni_config",
         }
         for method, marker in methods_to_mock.items():
             if marker not in request.keywords:

--- a/upstream/update.py
+++ b/upstream/update.py
@@ -80,7 +80,7 @@ class Release:
         return hash(self.name)
 
     def __eq__(self, other) -> bool:
-        """Comparible based on its name."""
+        """Comparable based on its name."""
         return isinstance(other, Release) and self.name == other.name
 
     def __lt__(self, other) -> bool:


### PR DESCRIPTION
## Summary
This pull request backports 2037236 fix to the `release_1.28` branch.