### PR TITLE
Instrument more detailed reports on `calicoctl` failures

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -625,14 +625,15 @@ class CalicoCharm(ops.CharmBase):
         @param int timeout: If the process does not terminate after timeout seconds,
                             raise a TimeoutExpired exception
         """
-        cmd = ["/opt/calicoctl/calicoctl"] + list(args)
+        cmd = ["/opt/calicoctl/calicoctl", "--log-level=debug"] + list(args)
         env = os.environ.copy()
         env.update(self._get_calicoctl_env())
         try:
             return subprocess.check_output(cmd, env=env, stderr=subprocess.PIPE, timeout=timeout)
         except (CalledProcessError, TimeoutExpired) as e:
-            log.error(e.stderr)
-            log.error(e.output)
+            log.error("env=%s", env)
+            log.error("out=%s", e.stdout.decode())
+            log.error("err=%s", e.stderr.decode())
             raise
 
     def _calicoctl_get(self, *args):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1051,7 +1051,7 @@ def test_calicoctl_get_raises(mock_calicoctl: mock.MagicMock, charm: CalicoCharm
 def test_calicoctl(mock_get: mock.MagicMock, mock_check: mock.MagicMock, charm: CalicoCharm):
     test_args = ("get", "version")
     mock_get.return_value = {"ETCD_KEY_FILE": "/tmp/test/path/key"}
-    expected_cmd = ["/opt/calicoctl/calicoctl"] + list(test_args)
+    expected_cmd = ["/opt/calicoctl/calicoctl", "--log-level=debug"] + list(test_args)
     expected_env = os.environ.copy()
     expected_env.update({"ETCD_KEY_FILE": "/tmp/test/path/key"})
 
@@ -1068,8 +1068,8 @@ def test_calicoctl_raises(
     mock_get: mock.MagicMock, mock_check: mock.MagicMock, charm: CalicoCharm
 ):
     test_args = ("get", "version")
-    expected_cmd = ["/opt/calicoctl/calicoctl"] + list(test_args)
-    mock_check.side_effect = CalledProcessError(1, expected_cmd, "some output", "some error")
+    expected_cmd = ["/opt/calicoctl/calicoctl", "--log-level=debug"] + list(test_args)
+    mock_check.side_effect = CalledProcessError(1, expected_cmd, b"some output", b"some error")
 
     with pytest.raises(CalledProcessError):
         charm.calicoctl(*test_args)


### PR DESCRIPTION
[LP#2064145](https://bugs.launchpad.net/charm-calico/+bug/2064145)

## Overview

calicoctl connects directly with etcd and can on occasion fail to find the node that corresponds to the node intended to configure.  It feels like we need more detail about the failure, but surely this isn't enough to address the issue in the bug. 

## Details
* Add a `log-level=debug` when executing calicoctl to configure the node. 
* decode the stdout and stderr from the command
* post the environment variables as well.

-------------
In some cases, users have reported when connected directly to the k8s api using `/root/.kube/config` the command works.  I wonder if using a fallback to this methodology might make sense???

We already know that `/root/.kube/config` must exist in order to apply the manifests so why not at least try it here?