### PR TITLE
[LP#2064145] debug logs produce event logs on failures

### DIFF
--- a/src/calico_manifests.py
+++ b/src/calico_manifests.py
@@ -403,7 +403,7 @@ class CalicoManifests(Manifests):
 
 
 def by_localtime(event: Event) -> datetime.datetime:
-    """Return the last timestamp of the event in local time."""
+    """Return the last timestamp of the event if available in local time, otherwise approximate with now."""
     dt = event.lastTimestamp or datetime.datetime.now(datetime.timezone.utc)
     return dt.astimezone()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -197,7 +197,13 @@ class CalicoCharm(ops.CharmBase):
                 "ignore-loose-rpf config is in conflict with rp_filter value"
             )
             return
-        if self.stored.deployed and self.stored.calico_configured:
+
+        if not self.stored.deployed:
+            return
+
+        if unready := self.collector.unready:
+            self.unit.status = WaitingStatus(", ".join(unready))
+        elif self.stored.calico_configured:
             self.unit.set_workload_version(self.collector.short_version)
             self.unit.status = ActiveStatus("Ready")
 


### PR DESCRIPTION
## Overview

The calico charm doesn't really bubble out any information about the resources deployed into kubernetes when it gets into trouble.  Because of this, it's difficult to diagnose situations like a pod not starting up.  And to make matters worse, on ephemeral clusters all we have are the charm logs after the fact -- no evidence of the daemonsets and deployments and pods while the cluster was alive. 


## Details
Add some debugging of kubernetes events around the DaemonSets, Deployments, and associated Pods into the charm logs so we can get some idea of why some charm deployments end up being stuck forever.

## Links
https://bugs.launchpad.net/charm-calico/+bug/2064145