### PR TITLE
Integration tests should use default-base, not series

### DIFF
--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -1,5 +1,5 @@
 description: A minimal two-machine Kubernetes cluster, appropriate for development.
-series: &series {{ series }}
+default-base: &default-base {{ base }}
 applications:
   kubernetes-control-plane:
     options:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,10 +11,10 @@ log = logging.getLogger(__name__)
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--series",
+        "--default-base",
         type=str,
         default="",
-        help="Set series for the machine units",
+        help="Set default-base for the machine units",
     )
 
 
@@ -31,9 +31,9 @@ async def k8s_core_yaml(ops_test, k8s_core_bundle):
 
 
 @pytest.fixture(scope="module")
-def series(k8s_core_yaml, request):
-    series = request.config.getoption("--series")
-    return series if series else k8s_core_yaml["series"]
+def base(k8s_core_yaml, request):
+    base = request.config.getoption("--default-base")
+    return base if base else k8s_core_yaml["default-base"]
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_calico_integration.py
+++ b/tests/integration/test_calico_integration.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
-async def test_build_and_deploy(ops_test, k8s_core_bundle, series):
+async def test_build_and_deploy(ops_test, k8s_core_bundle, base):
     log.info("Building charm")
     calico_charm = await ops_test.build_charm(".")
 
@@ -34,7 +34,7 @@ async def test_build_and_deploy(ops_test, k8s_core_bundle, series):
         k8s_core_bundle,
         Path("tests/data/charm.yaml"),
         calico_charm=calico_charm,
-        series=series,
+        base=base,
         resource_path=resource_path,
     )
 


### PR DESCRIPTION
### Overview
Stop using `series` in bundles, but rather `default-base`

### Details
`series` will be deprecated in juju 4, preparation of future tests now that `kubernetes-core` in the edge channel uses `default-base`